### PR TITLE
Relax workflow date inputs for fortune snapshot

### DIFF
--- a/.github/workflows/fortune-top10-dataframe.yml
+++ b/.github/workflows/fortune-top10-dataframe.yml
@@ -5,12 +5,12 @@ on:
     inputs:
       start:
         description: Inclusive start period (YYYY-MM-DD)
-        required: true
-        default: '2025-01-01'
+        required: false
+        default: ''
       end:
         description: Inclusive end period (YYYY-MM-DD)
-        required: true
-        default: '2025-12-31'
+        required: false
+        default: ''
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -28,13 +28,12 @@ python scripts/build_statements.py --tickers-csv inputs/tickers.csv --out-dir da
 ```
 
 Collect the first ten Fortune 1000 + tech tickers into a consolidated CSV for a
-given date window:
+given date window (leaving the optional `--start`/`--end` flags blank matches the
+workflow defaults and collects all available history):
 ```bash
 python scripts/collect_financial_frames.py \
   --tickers-csv inputs/fortune_1000_plus_tech_firms.csv \
   --limit 10 \
-  --start 2025-01-01 \
-  --end 2025-12-31 \
   --out-csv artifacts/fortune_top10_statements.csv
 ```
 


### PR DESCRIPTION
## Summary
- allow the fortune snapshot workflow to dispatch without forcing a future-dated window by defaulting the date inputs to blanks
- document the optional start/end flags in the README so the local example mirrors the workflow behaviour

## Testing
- python scripts/collect_financial_frames.py --tickers-csv inputs/fortune_1000_plus_tech_firms.csv --limit 10 --start "" --end "" --out-csv artifacts/fortune_top10_statements.csv


------
https://chatgpt.com/codex/tasks/task_e_68e04c868b248330b9acee97552c054a