### PR TITLE
Fix Berkshire Hathaway ticker symbol for Yahoo Finance

### DIFF
--- a/inputs/fortune1000_with_tech_firms.csv
+++ b/inputs/fortune1000_with_tech_firms.csv
@@ -1,7 +1,7 @@
 
 Company,Ticker
 "Wal-Mart Stores, Inc.",WMT
-Berkshire Hathaway Inc.,BRKA
+Berkshire Hathaway Inc.,BRK-A
 "Apple, Inc.",AAPL
 Exxon Mobil Corporation,XOM
 McKesson Corporation,MCK

--- a/inputs/fortune_1000_plus_tech_firms.csv
+++ b/inputs/fortune_1000_plus_tech_firms.csv
@@ -1,6 +1,6 @@
 # Fortune 1000 (2017) + tech firms tickers
 WMT
-BRKA
+BRK-A
 AAPL
 XOM
 MCK


### PR DESCRIPTION
## Summary
- replace the Berkshire Hathaway Class A ticker with the Yahoo Finance compliant BRK-A symbol in both ticker lists

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e04c8dec9c8330a969165b4acb8c5b