### PR TITLE
Export Fortune snapshot statements as per-slice CSV artifacts

### DIFF
--- a/.github/workflows/fortune-top10-dataframe.yml
+++ b/.github/workflows/fortune-top10-dataframe.yml
@@ -27,16 +27,51 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Collect statements into CSV
+      - name: Collect statements into CSV slices
         run: |
           python scripts/collect_financial_frames.py \
             --tickers-csv inputs/fortune_1000_plus_tech_firms.csv \
             --limit 10 \
             --start '${{ inputs.start }}' \
             --end '${{ inputs.end }}' \
-            --out-csv artifacts/fortune_top10_statements.csv
+            --out-dir artifacts/fortune_top10_statements
 
-      - uses: actions/upload-artifact@v4
+      - name: List generated slices
+        run: |
+          ls -al artifacts/fortune_top10_statements
+
+      - name: Upload income statement annual slice
+        uses: actions/upload-artifact@v4
         with:
-          name: fortune-top10-statements
-          path: artifacts/fortune_top10_statements.csv
+          name: fortune-top10-income-statement-annual
+          path: artifacts/fortune_top10_statements/income_statement_annual.csv
+
+      - name: Upload balance sheet annual slice
+        uses: actions/upload-artifact@v4
+        with:
+          name: fortune-top10-balance-sheet-annual
+          path: artifacts/fortune_top10_statements/balance_sheet_annual.csv
+
+      - name: Upload cash flow annual slice
+        uses: actions/upload-artifact@v4
+        with:
+          name: fortune-top10-cash-flow-annual
+          path: artifacts/fortune_top10_statements/cash_flow_annual.csv
+
+      - name: Upload income statement quarterly slice
+        uses: actions/upload-artifact@v4
+        with:
+          name: fortune-top10-income-statement-quarterly
+          path: artifacts/fortune_top10_statements/income_statement_quarterly.csv
+
+      - name: Upload balance sheet quarterly slice
+        uses: actions/upload-artifact@v4
+        with:
+          name: fortune-top10-balance-sheet-quarterly
+          path: artifacts/fortune_top10_statements/balance_sheet_quarterly.csv
+
+      - name: Upload cash flow quarterly slice
+        uses: actions/upload-artifact@v4
+        with:
+          name: fortune-top10-cash-flow-quarterly
+          path: artifacts/fortune_top10_statements/cash_flow_quarterly.csv

--- a/README.md
+++ b/README.md
@@ -27,16 +27,19 @@ Generate locally:
 python scripts/build_statements.py --tickers-csv inputs/tickers.csv --out-dir data
 ```
 
-Collect the first ten Fortune 1000 + tech tickers into a consolidated CSV for a
-given date window:
+Collect the first ten Fortune 1000 + tech tickers into per-statement CSV slices
+for a given date window:
 ```bash
 python scripts/collect_financial_frames.py \
   --tickers-csv inputs/fortune_1000_plus_tech_firms.csv \
   --limit 10 \
   --start 2025-01-01 \
   --end 2025-12-31 \
-  --out-csv artifacts/fortune_top10_statements.csv
+  --out-dir artifacts/fortune_top10_statements
 ```
+
+This writes six files (e.g., `income_statement_annual.csv`) into the provided
+directory so each slice can be uploaded or consumed independently.
 
 Schema validate:
 ```bash

--- a/scripts/collect_financial_frames.py
+++ b/scripts/collect_financial_frames.py
@@ -1,8 +1,9 @@
-"""Utilities to bundle statement data for a list of tickers into a single DataFrame.
+"""Utilities to bundle statement data for a list of tickers into CSV slices.
 
 This script mirrors the ticker loading behaviour from ``build_statements.py`` but
 shapes the yfinance payloads into a tidy ``pandas`` DataFrame.  It is designed to
-run in GitHub Actions where the resulting CSV can be uploaded as an artifact.
+run in GitHub Actions where the resulting CSV slices can be uploaded as
+artifacts.
 """
 
 from __future__ import annotations
@@ -153,7 +154,9 @@ def collect_statements(
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Collect ticker statements into a CSV")
+    parser = argparse.ArgumentParser(
+        description="Collect ticker statements and emit per-slice CSV files"
+    )
     parser.add_argument("--tickers-csv", required=True, type=Path)
     parser.add_argument("--limit", type=int, default=None, help="Number of tickers to load")
     parser.add_argument(
@@ -169,17 +172,38 @@ def main() -> None:
         help="Inclusive period end (YYYY-MM-DD)",
     )
     parser.add_argument(
-        "--out-csv",
+        "--out-dir",
         type=Path,
         required=True,
-        help="Where to write the consolidated CSV",
+        help="Directory where CSV slices will be written",
     )
 
     args = parser.parse_args()
     tickers = _load_tickers(args.tickers_csv, args.limit)
     df = collect_statements(tickers, start=args.start, end=args.end)
-    args.out_csv.parent.mkdir(parents=True, exist_ok=True)
-    df.to_csv(args.out_csv, index=False)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Materialize each (statement, frequency) slice into its own CSV to make
+    # downstream artifact uploads easier to target.
+    ordered_columns = ["ticker", "statement", "frequency", "metric", "period", "value"]
+    statement_frequencies = (
+        ("income_statement", "annual"),
+        ("balance_sheet", "annual"),
+        ("cash_flow", "annual"),
+        ("income_statement", "quarterly"),
+        ("balance_sheet", "quarterly"),
+        ("cash_flow", "quarterly"),
+    )
+
+    for statement, frequency in statement_frequencies:
+        slice_df = df.loc[
+            (df["statement"] == statement) & (df["frequency"] == frequency),
+            ordered_columns,
+        ].copy()
+        if not slice_df.empty:
+            slice_df = slice_df.sort_values(["ticker", "period", "metric"])  # stable order
+        out_path = args.out_dir / f"{statement}_{frequency}.csv"
+        slice_df.to_csv(out_path, index=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update the financial frame collector to accept an output directory and emit one CSV per statement/frequency slice
- adjust the Fortune Top 10 workflow to upload each slice as its own artifact
- document the new CLI usage in the README so local runs mirror the workflow layout

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e04c900eec833085af6b9b2dabfa6c