### PR TITLE
Handle invalid end dates in financial frame collection

### DIFF
--- a/scripts/collect_financial_frames.py
+++ b/scripts/collect_financial_frames.py
@@ -9,6 +9,7 @@ artifacts.
 from __future__ import annotations
 
 import argparse
+import calendar
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
@@ -68,6 +69,18 @@ def _normalize_statement(
     return normalized
 
 
+def _coerce_date(date_str: str) -> pd.Timestamp:
+    """Return a Timestamp parsed from ``YYYY-MM-DD`` strings, clamping invalid days."""
+
+    timestamp = pd.to_datetime(date_str, errors="coerce")
+    if not pd.isna(timestamp):
+        return timestamp
+
+    year, month, day = (int(part) for part in date_str.split("-"))
+    _, max_day = calendar.monthrange(year, month)
+    return pd.Timestamp(year=year, month=month, day=min(day, max_day))
+
+
 def collect_statements(
     tickers: Iterable[str],
     start: str | None = None,
@@ -75,8 +88,8 @@ def collect_statements(
 ) -> pd.DataFrame:
     """Return a tidy DataFrame of statement slices for the provided tickers."""
 
-    start_ts = pd.to_datetime(start) if start else None
-    end_ts = pd.to_datetime(end) if end else None
+    start_ts = _coerce_date(start) if start else None
+    end_ts = _coerce_date(end) if end else None
 
     records: list[StatementSlice] = []
     for ticker in tickers:

--- a/tests/test_collect_financial_frames.py
+++ b/tests/test_collect_financial_frames.py
@@ -2,7 +2,11 @@ from datetime import datetime
 
 import pandas as pd
 
-from scripts.collect_financial_frames import _normalize_statement, collect_statements
+from scripts.collect_financial_frames import (
+    _coerce_date,
+    _normalize_statement,
+    collect_statements,
+)
 
 
 def test_normalize_statement_filters_by_period():
@@ -52,3 +56,8 @@ def test_collect_statements_handles_empty(monkeypatch):
     df = collect_statements(["FOO"], start="2025-01-01", end="2025-12-31")
     assert df.empty
     assert list(df.columns) == ["ticker", "statement", "frequency", "metric", "period", "value"]
+
+
+def test_coerce_date_clamps_invalid_day():
+    assert _coerce_date("2025-06-31") == pd.Timestamp("2025-06-30")
+    assert _coerce_date("2024-02-29") == pd.Timestamp("2024-02-29")


### PR DESCRIPTION
## Summary
- clamp invalid start and end date inputs when collecting financial statements
- add regression test covering the new date coercion helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0507f79e883309e6ebf6bff86d836